### PR TITLE
feat: tick PR relative time every minute

### DIFF
--- a/components/pr.tsx
+++ b/components/pr.tsx
@@ -8,9 +8,9 @@ import type {
 import { Avatar } from 'components/avatar';
 import { useDisplayMode } from 'components/display-mode-context';
 import { PrStatus } from 'components/pr-status';
+import { RelativeTime } from 'components/relative-time';
 import { ReviewerAvatars } from 'components/reviewer-avatars';
 import cn from 'utils/cn';
-import { formatRelativeTime } from 'utils/format-relative-time';
 
 type Props = {
   prKey: pr_pullRequest$key;
@@ -41,7 +41,7 @@ const CompactPr = ({ pr }: CompactPrProps) => (
       {pr.title}
     </span>
     <span className="ml-auto shrink-0 text-xs text-slate-600 dark:text-catppuccin-subtext0">
-      {formatRelativeTime(pr.mergedAt ?? pr.updatedAt)}
+      <RelativeTime dateString={pr.mergedAt ?? pr.updatedAt} />
     </span>
     <PrStatus prKey={pr} />
   </a>
@@ -85,7 +85,7 @@ export const Pr = ({ prKey }: Props) => {
             </div>
           </div>
           <div className="flex shrink-0 pl-2">
-            {formatRelativeTime(pr.mergedAt ?? pr.updatedAt)}
+            <RelativeTime dateString={pr.mergedAt ?? pr.updatedAt} />
           </div>
         </div>
         <div className="flex justify-between">

--- a/components/relative-time.tsx
+++ b/components/relative-time.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { formatRelativeTime } from 'utils/format-relative-time';
+
+const TICK_INTERVAL = 60 * 1000;
+
+const subscribers = new Set<(now: number) => void>();
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+const subscribe = (callback: (now: number) => void) => {
+  subscribers.add(callback);
+  if (intervalId === null) {
+    intervalId = setInterval(() => {
+      const now = Date.now();
+      for (const cb of subscribers) cb(now);
+    }, TICK_INTERVAL);
+  }
+  return () => {
+    subscribers.delete(callback);
+    if (subscribers.size === 0 && intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+};
+
+type Props = {
+  dateString: string;
+};
+
+export const RelativeTime = ({ dateString }: Props) => {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => subscribe(setNow), []);
+  return <>{formatRelativeTime(dateString, now)}</>;
+};

--- a/utils/format-relative-time.ts
+++ b/utils/format-relative-time.ts
@@ -3,10 +3,12 @@ const HOUR = 60 * MINUTE;
 const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 
-export const formatRelativeTime = (dateString: string): string => {
+export const formatRelativeTime = (
+  dateString: string,
+  now: number = Date.now()
+): string => {
   const date = new Date(dateString);
-  const now = new Date();
-  const diff = now.getTime() - date.getTime();
+  const diff = now - date.getTime();
 
   if (diff < MINUTE) {
     return 'just now';


### PR DESCRIPTION
Previously the displayed "X ago" time only refreshed when fragment data changed. Since updatedAt rarely changes between polls, values went stale until the next real change. Add a RelativeTime component backed by a single shared 60s interval, and thread an explicit `now` arg into formatRelativeTime so React Compiler can't memoize the call against stale time.