### PR TITLE
chore: bump Relay to 21 and TypeScript to 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,8 +12,8 @@
         "@pr-monitor/ui": "workspace:*",
         "react": "19.2.6",
         "react-dom": "19.2.6",
-        "react-relay": "20.1.1",
-        "relay-runtime": "20.1.1",
+        "react-relay": "21.0.0",
+        "relay-runtime": "21.0.0",
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -25,7 +25,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@types/react-relay": "18.2.1",
-        "@types/relay-runtime": "20.1.0",
+        "@types/relay-runtime": "20.1.1",
         "@typescript-eslint/parser": "8.50.1",
         "@vitejs/plugin-react": "^6.0.2",
         "babel-plugin-relay": "^21.0.0",
@@ -43,7 +43,7 @@
         "prettier": "3.7.4",
         "prettier-plugin-tailwindcss": "0.7.2",
         "tailwindcss": "^3.4.1",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "typescript-eslint": "8.50.1",
         "vite": "^8.0.14",
       },
@@ -54,9 +54,6 @@
       "dependencies": {
         "@primer/octicons-react": "19.21.1",
         "clsx": "^2.1.1",
-        "graphql": "16.12.0",
-        "react-relay": "20.1.1",
-        "relay-runtime": "20.1.1",
         "tailwind-merge": "^2.4.0",
       },
       "devDependencies": {
@@ -64,7 +61,7 @@
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "@types/react-relay": "18.2.1",
-        "@types/relay-runtime": "20.1.0",
+        "@types/relay-runtime": "20.1.1",
         "@typescript-eslint/parser": "8.50.1",
         "eslint": "9.39.2",
         "eslint-import-resolver-typescript": "4.4.4",
@@ -75,17 +72,23 @@
         "eslint-plugin-relay": "2.0.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "4.3.0",
+        "graphql": "16.12.0",
         "prettier": "3.7.4",
         "prettier-plugin-tailwindcss": "0.7.2",
         "react": "19.2.6",
         "react-dom": "19.2.6",
-        "relay-compiler": "20.1.1",
-        "typescript": "5.9.3",
+        "react-relay": "21.0.0",
+        "relay-compiler": "21.0.0",
+        "relay-runtime": "21.0.0",
+        "typescript": "6.0.3",
         "typescript-eslint": "8.50.1",
       },
       "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "graphql": "^16",
+        "react": "^19",
+        "react-dom": "^19",
+        "react-relay": "^21",
+        "relay-runtime": "^21",
       },
     },
     "packages/www": {
@@ -98,8 +101,8 @@
         "next": "16.2.5",
         "react": "19.2.6",
         "react-dom": "19.2.6",
-        "react-relay": "20.1.1",
-        "relay-runtime": "20.1.1",
+        "react-relay": "21.0.0",
+        "relay-runtime": "21.0.0",
       },
       "devDependencies": {
         "@eslint/js": "9.39.2",
@@ -124,7 +127,7 @@
         "prettier-plugin-tailwindcss": "0.7.2",
         "server-only": "^0.0.1",
         "tailwindcss": "^3.4.1",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "typescript-eslint": "8.50.1",
       },
     },
@@ -374,7 +377,7 @@
 
     "@types/react-relay": ["@types/react-relay@18.2.1", "", { "dependencies": { "@types/react": "*", "@types/relay-runtime": "*" } }, "sha512-KgmFapsxAylhxcFfaAv5GZZJhTHnDvV8IDZVsUm5afpJUvgZC1Y68ssfOGsFfiFY/2EhxHM/YPfpdKbfmF3Ecg=="],
 
-    "@types/relay-runtime": ["@types/relay-runtime@20.1.0", "", {}, "sha512-KujDVDPWjvRxd4YBTp0ppYqOCrJhsVwH8v18vicUBFRfgG/mqEPfK1rpI2Bz7vL08/CUiyHv7CR3CnqE4PUpbA=="],
+    "@types/relay-runtime": ["@types/relay-runtime@20.1.1", "", {}, "sha512-loM2iJteknnJcsxrynmBVb7pIDkSkJUuCMnAa/oDFcrvaxkDvq8iy0J2UshMdDy14iJJocDblXeAu7c6Q1+Ucw=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.50.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.50.1", "@typescript-eslint/type-utils": "8.50.1", "@typescript-eslint/utils": "8.50.1", "@typescript-eslint/visitor-keys": "8.50.1", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.50.1", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw=="],
 
@@ -1002,7 +1005,7 @@
 
     "react-refresh": ["react-refresh@0.13.0", "", {}, "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg=="],
 
-    "react-relay": ["react-relay@20.1.1", "", { "dependencies": { "@babel/runtime": "^7.25.0", "fbjs": "^3.0.2", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "relay-runtime": "20.1.1" }, "peerDependencies": { "react": "^16.9.0 || ^17 || ^18 || ^19" } }, "sha512-pwl7wHHXCOx32dOg4TVNkhVojgGVvOBMo9pcMGeM1BIFYvmwGauKTtBB+qr5buXHGooCL8TXjMVg+ZLizIsbeQ=="],
+    "react-relay": ["react-relay@21.0.0", "", { "dependencies": { "@babel/runtime": "^7.25.0", "fbjs": "^3.0.2", "invariant": "^2.2.4", "nullthrows": "^1.1.1", "relay-runtime": "21.0.0" }, "peerDependencies": { "react": "^16.9.0 || ^17 || ^18 || ^19" } }, "sha512-lGnL9lmDVIHX/mF4qFGC9DXIm26RqMDNI1lBoxrAYXtk7i1Llo1NB3aC0Rf7fRVq6MY3ycBC8eKdYTOmeLloaA=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
@@ -1012,9 +1015,9 @@
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
-    "relay-compiler": ["relay-compiler@20.1.1", "", { "bin": { "relay-compiler": "cli.js" } }, "sha512-J/FFFLS/3vnbDkyQMw8l3Ev7dNHXMgC1RAs0fITz4Q63TFPOw142knKxY1Mm5ZZBABkAs9g2JghXaqM+phwTxw=="],
+    "relay-compiler": ["relay-compiler@21.0.0", "", { "bin": { "relay-compiler": "cli.js" } }, "sha512-ni8U67uybKAE1Aeh+tHw7Dmoeuvgm+UmEohJH8bAcoCnMkFX5Nj/6kGR/KyxcOSxdcXIkApAzurbXX+lUda6Wg=="],
 
-    "relay-runtime": ["relay-runtime@20.1.1", "", { "dependencies": { "@babel/runtime": "^7.25.0", "fbjs": "^3.0.2", "invariant": "^2.2.4" } }, "sha512-N98ZkkyuIHdXmHaPuljihM1QbFYXATF0gxA0CESFphszsQzXs9A/zZloVfzdOI/xg3B3CfM/5nozvIoeTDIcfw=="],
+    "relay-runtime": ["relay-runtime@21.0.0", "", { "dependencies": { "@babel/runtime": "^7.25.0", "fbjs": "^3.0.2", "invariant": "^2.2.4" } }, "sha512-CEKncRm8BOPT3IlymyfTVzQ8jNDgw0KrCAwel0QMG1R+ESpeMVTrWJzTGCjrzzT5MT2AEWZdCkClZ0JtXSKmUw=="],
 
     "resolve": ["resolve@2.0.0-next.7", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.2", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ=="],
 
@@ -1128,7 +1131,7 @@
 
     "typed-array-length": ["typed-array-length@1.0.7", "", { "dependencies": { "call-bind": "^1.0.7", "for-each": "^0.3.3", "gopd": "^1.0.1", "is-typed-array": "^1.1.13", "possible-typed-array-names": "^1.0.0", "reflect.getprototypeof": "^1.0.6" } }, "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-eslint": ["typescript-eslint@8.50.1", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.50.1", "@typescript-eslint/parser": "8.50.1", "@typescript-eslint/typescript-estree": "8.50.1", "@typescript-eslint/utils": "8.50.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-ytTHO+SoYSbhAH9CrYnMhiLx8To6PSSvqnvXyPUgPETCvB6eBKmTI9w6XMPS3HsBRGkwTVBX+urA8dYQx6bHfQ=="],
 
@@ -1188,11 +1191,27 @@
 
     "@rollup/pluginutils/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "@types/react-relay/@types/relay-runtime": ["@types/relay-runtime@20.1.0", "", {}, "sha512-KujDVDPWjvRxd4YBTp0ppYqOCrJhsVwH8v18vicUBFRfgG/mqEPfK1rpI2Bz7vL08/CUiyHv7CR3CnqE4PUpbA=="],
+
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/eslint-plugin/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@typescript-eslint/parser/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@typescript-eslint/project-service/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@typescript-eslint/tsconfig-utils/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@typescript-eslint/type-utils/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
+
+    "@typescript-eslint/typescript-estree/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@typescript-eslint/utils/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -1229,6 +1248,8 @@
     "tailwindcss/resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
+
+    "typescript-eslint/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@eslint/eslintrc/import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -14,8 +14,8 @@
     "@pr-monitor/ui": "workspace:*",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "react-relay": "20.1.1",
-    "relay-runtime": "20.1.1"
+    "react-relay": "21.0.0",
+    "relay-runtime": "21.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
@@ -27,7 +27,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/react-relay": "18.2.1",
-    "@types/relay-runtime": "20.1.0",
+    "@types/relay-runtime": "20.1.1",
     "@typescript-eslint/parser": "8.50.1",
     "@vitejs/plugin-react": "^6.0.2",
     "babel-plugin-relay": "^21.0.0",
@@ -45,7 +45,7 @@
     "prettier": "3.7.4",
     "prettier-plugin-tailwindcss": "0.7.2",
     "tailwindcss": "^3.4.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.50.1",
     "vite": "^8.0.14"
   }

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -13,6 +13,7 @@
     "jsx": "react-jsx",
     "incremental": true,
     "target": "ES2017",
+    "types": ["chrome", "vite/client"],
     "paths": {
       "components/*": ["../ui/components/*"],
       "utils/*": ["../ui/utils/*"],

--- a/packages/ui/components/__generated__/MentionedPrListPaginationQuery.graphql.ts
+++ b/packages/ui/components/__generated__/MentionedPrListPaginationQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<b195ffd442904411128f4cdd2e6a75b2>>
+ * @generated SignedSource<<3d3cb7d7571848c93cc0186dba230b04>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -81,7 +80,7 @@ v4 = {
 v5 = {
   "kind": "InlineFragment",
   "selections": [
-    (v3/*: any*/)
+    (v3/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -94,9 +93,9 @@ v6 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/)
+    (v2/*:: as any*/),
+    (v4/*:: as any*/),
+    (v5/*:: as any*/)
   ],
   "storageKey": null
 },
@@ -108,11 +107,11 @@ v7 = [
   }
 ],
 v8 = [
-  (v4/*: any*/)
+  (v4/*:: as any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "MentionedPrListPaginationQuery",
@@ -139,13 +138,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "MentionedPrListPaginationQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -167,12 +166,12 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
-                      (v6/*: any*/),
+                      (v3/*:: as any*/),
+                      (v6/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -230,7 +229,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -298,13 +297,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -326,10 +325,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
+                                  (v2/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -349,21 +348,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -372,7 +371,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -386,8 +385,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v6/*: any*/),
-                              (v3/*: any*/)
+                              (v6/*:: as any*/),
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -398,7 +397,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v5/*: any*/)
+                  (v5/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -442,7 +441,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "filters": [
           "query",
           "type"
@@ -465,6 +464,6 @@ return {
 };
 })();
 
-(node as any).hash = "44e3728aec3a584607c7a7658294d809";
+(node as any).hash = "86f4199fc922228f199f9672a95366d5";
 
 export default node;

--- a/packages/ui/components/__generated__/MyPrListPaginationQuery.graphql.ts
+++ b/packages/ui/components/__generated__/MyPrListPaginationQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<516bc94a0c8d373a281c0d1e698f3485>>
+ * @generated SignedSource<<d3f63069ad66337bf6d14dee7fd98b37>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -81,7 +80,7 @@ v4 = {
 v5 = {
   "kind": "InlineFragment",
   "selections": [
-    (v3/*: any*/)
+    (v3/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -94,9 +93,9 @@ v6 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/)
+    (v2/*:: as any*/),
+    (v4/*:: as any*/),
+    (v5/*:: as any*/)
   ],
   "storageKey": null
 },
@@ -108,11 +107,11 @@ v7 = [
   }
 ],
 v8 = [
-  (v4/*: any*/)
+  (v4/*:: as any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "MyPrListPaginationQuery",
@@ -139,13 +138,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "MyPrListPaginationQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -167,12 +166,12 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
-                      (v6/*: any*/),
+                      (v3/*:: as any*/),
+                      (v6/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -230,7 +229,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -298,13 +297,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -326,10 +325,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
+                                  (v2/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -349,21 +348,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -372,7 +371,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -386,8 +385,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v6/*: any*/),
-                              (v3/*: any*/)
+                              (v6/*:: as any*/),
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -398,7 +397,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v5/*: any*/)
+                  (v5/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -442,7 +441,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "filters": [
           "query",
           "type"
@@ -465,6 +464,6 @@ return {
 };
 })();
 
-(node as any).hash = "8e8d3e0fe7b7e21366d69c11aaf5f763";
+(node as any).hash = "d2cd64f6c9d57770504f6f0e28b988de";
 
 export default node;

--- a/packages/ui/components/__generated__/RepoPrListPaginationQuery.graphql.ts
+++ b/packages/ui/components/__generated__/RepoPrListPaginationQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<5330afdfe8d009cc0274e4d34ab0a8a3>>
+ * @generated SignedSource<<e35f8d460c614df405d49e8d45b68646>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -57,7 +56,7 @@ v2 = [
     "name": "first",
     "variableName": "count"
   },
-  (v1/*: any*/),
+  (v1/*:: as any*/),
   {
     "kind": "Literal",
     "name": "type",
@@ -88,7 +87,7 @@ v5 = {
 v6 = {
   "kind": "InlineFragment",
   "selections": [
-    (v4/*: any*/)
+    (v4/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -101,9 +100,9 @@ v7 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v3/*: any*/),
-    (v5/*: any*/),
-    (v6/*: any*/)
+    (v3/*:: as any*/),
+    (v5/*:: as any*/),
+    (v6/*:: as any*/)
   ],
   "storageKey": null
 },
@@ -115,11 +114,11 @@ v8 = [
   }
 ],
 v9 = [
-  (v5/*: any*/)
+  (v5/*:: as any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "RepoPrListPaginationQuery",
@@ -136,7 +135,7 @@ return {
             "name": "cursor",
             "variableName": "cursor"
           },
-          (v1/*: any*/)
+          (v1/*:: as any*/)
         ],
         "kind": "FragmentSpread",
         "name": "repoPrList_search"
@@ -147,13 +146,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "RepoPrListPaginationQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -175,11 +174,11 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/),
+                  (v3/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v4/*: any*/),
+                      (v4/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -187,7 +186,7 @@ return {
                         "name": "mergedAt",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      (v7/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -238,7 +237,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v4/*: any*/)
+                          (v4/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -306,13 +305,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v4/*: any*/)
+                          (v4/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v8/*: any*/),
+                        "args": (v8/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -334,10 +333,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v3/*: any*/),
+                                  (v3/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v9/*: any*/),
+                                    "selections": (v9/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -357,21 +356,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v9/*: any*/),
+                                    "selections": (v9/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v9/*: any*/),
+                                    "selections": (v9/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v6/*: any*/)
+                                  (v6/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v4/*: any*/)
+                              (v4/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -380,7 +379,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v8/*: any*/),
+                        "args": (v8/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -394,8 +393,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v7/*: any*/),
-                              (v4/*: any*/)
+                              (v7/*:: as any*/),
+                              (v4/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -406,7 +405,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v6/*: any*/)
+                  (v6/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -450,7 +449,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2/*:: as any*/),
         "filters": [
           "query",
           "type"
@@ -473,6 +472,6 @@ return {
 };
 })();
 
-(node as any).hash = "bc2a0d6e1b13ad0dcc57eabfb9cca4c5";
+(node as any).hash = "e9bac8e6e45ab8637d0a02da65560412";
 
 export default node;

--- a/packages/ui/components/__generated__/ReviewPrListPaginationQuery.graphql.ts
+++ b/packages/ui/components/__generated__/ReviewPrListPaginationQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<2f0ba1245f2e26dcf6cbcab56de37b13>>
+ * @generated SignedSource<<6ab5dbb213b538125d0d03283cfb84b7>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -81,7 +80,7 @@ v4 = {
 v5 = {
   "kind": "InlineFragment",
   "selections": [
-    (v3/*: any*/)
+    (v3/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -94,9 +93,9 @@ v6 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/)
+    (v2/*:: as any*/),
+    (v4/*:: as any*/),
+    (v5/*:: as any*/)
   ],
   "storageKey": null
 },
@@ -108,11 +107,11 @@ v7 = [
   }
 ],
 v8 = [
-  (v4/*: any*/)
+  (v4/*:: as any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "ReviewPrListPaginationQuery",
@@ -139,13 +138,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "ReviewPrListPaginationQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -167,11 +166,11 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
+                      (v3/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -179,7 +178,7 @@ return {
                         "name": "reviewDecision",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v6/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -237,7 +236,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -298,13 +297,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -326,10 +325,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
+                                  (v2/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -349,21 +348,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -372,7 +371,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -386,8 +385,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v6/*: any*/),
-                              (v3/*: any*/)
+                              (v6/*:: as any*/),
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -398,7 +397,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v5/*: any*/)
+                  (v5/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -442,7 +441,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "filters": [
           "query",
           "type"
@@ -465,6 +464,6 @@ return {
 };
 })();
 
-(node as any).hash = "a847f9c12f3de69700c665003aa96d4a";
+(node as any).hash = "47a5275434b550171444688b14730bad";
 
 export default node;

--- a/packages/ui/components/__generated__/ReviewedPrListChangesRequestedPaginationQuery.graphql.ts
+++ b/packages/ui/components/__generated__/ReviewedPrListChangesRequestedPaginationQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<13deed9e110ecbd6230907a6acd5e6a5>>
+ * @generated SignedSource<<bc795dbc07f6183e7ac996de5e4c9c83>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -81,7 +80,7 @@ v4 = {
 v5 = {
   "kind": "InlineFragment",
   "selections": [
-    (v3/*: any*/)
+    (v3/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -94,9 +93,9 @@ v6 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/)
+    (v2/*:: as any*/),
+    (v4/*:: as any*/),
+    (v5/*:: as any*/)
   ],
   "storageKey": null
 },
@@ -108,11 +107,11 @@ v7 = [
   }
 ],
 v8 = [
-  (v4/*: any*/)
+  (v4/*:: as any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "ReviewedPrListChangesRequestedPaginationQuery",
@@ -139,13 +138,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "ReviewedPrListChangesRequestedPaginationQuery",
     "selections": [
       {
         "alias": "changesRequested",
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -167,11 +166,11 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
+                      (v3/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -179,7 +178,7 @@ return {
                         "name": "reviewDecision",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v6/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -237,7 +236,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -298,13 +297,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -326,10 +325,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
+                                  (v2/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -349,21 +348,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -372,7 +371,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -386,8 +385,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v6/*: any*/),
-                              (v3/*: any*/)
+                              (v6/*:: as any*/),
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -398,7 +397,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v5/*: any*/)
+                  (v5/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -442,7 +441,7 @@ return {
       },
       {
         "alias": "changesRequested",
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "filters": [
           "query",
           "type"
@@ -465,6 +464,6 @@ return {
 };
 })();
 
-(node as any).hash = "e5f626be75366815c23fcf78887dd5e1";
+(node as any).hash = "6cf1be154913ca8fffee1d7bf2faf6e1";
 
 export default node;

--- a/packages/ui/components/__generated__/ReviewedPrListPaginationQuery.graphql.ts
+++ b/packages/ui/components/__generated__/ReviewedPrListPaginationQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<70bf2a9cf3b53a06895a54d882f618a1>>
+ * @generated SignedSource<<c2f115d8916fc55997031fd9e48916d2>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -81,7 +80,7 @@ v4 = {
 v5 = {
   "kind": "InlineFragment",
   "selections": [
-    (v3/*: any*/)
+    (v3/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -94,9 +93,9 @@ v6 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/)
+    (v2/*:: as any*/),
+    (v4/*:: as any*/),
+    (v5/*:: as any*/)
   ],
   "storageKey": null
 },
@@ -108,11 +107,11 @@ v7 = [
   }
 ],
 v8 = [
-  (v4/*: any*/)
+  (v4/*:: as any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "ReviewedPrListPaginationQuery",
@@ -139,13 +138,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "ReviewedPrListPaginationQuery",
     "selections": [
       {
         "alias": "reviewed",
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -167,12 +166,12 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
-                      (v6/*: any*/),
+                      (v3/*:: as any*/),
+                      (v6/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -230,7 +229,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -298,13 +297,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -326,10 +325,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
+                                  (v2/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -349,21 +348,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -372,7 +371,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -386,8 +385,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v6/*: any*/),
-                              (v3/*: any*/)
+                              (v6/*:: as any*/),
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -398,7 +397,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v5/*: any*/)
+                  (v5/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -442,7 +441,7 @@ return {
       },
       {
         "alias": "reviewed",
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "filters": [
           "query",
           "type"
@@ -465,6 +464,6 @@ return {
 };
 })();
 
-(node as any).hash = "1262404a387032481886101252e8017c";
+(node as any).hash = "9d1a3d003e081b60888470ca40e84ab4";
 
 export default node;

--- a/packages/ui/components/__generated__/mentionedPrListQuery.graphql.ts
+++ b/packages/ui/components/__generated__/mentionedPrListQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<13d52886d25491d81d3ba07590354f30>>
+ * @generated SignedSource<<54bffc39b25f4312fa18fddfbfec01a8>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -26,7 +25,7 @@ var v0 = {
   "value": 10
 },
 v1 = [
-  (v0/*: any*/),
+  (v0/*:: as any*/),
   {
     "kind": "Literal",
     "name": "query",
@@ -62,7 +61,7 @@ v4 = {
 v5 = {
   "kind": "InlineFragment",
   "selections": [
-    (v3/*: any*/)
+    (v3/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -75,17 +74,17 @@ v6 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/)
+    (v2/*:: as any*/),
+    (v4/*:: as any*/),
+    (v5/*:: as any*/)
   ],
   "storageKey": null
 },
 v7 = [
-  (v0/*: any*/)
+  (v0/*:: as any*/)
 ],
 v8 = [
-  (v4/*: any*/)
+  (v4/*:: as any*/)
 ];
 return {
   "fragment": {
@@ -111,7 +110,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -133,12 +132,12 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
-                      (v6/*: any*/),
+                      (v3/*:: as any*/),
+                      (v6/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -196,7 +195,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -264,13 +263,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -292,10 +291,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
+                                  (v2/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -315,21 +314,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -338,7 +337,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -352,8 +351,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v6/*: any*/),
-                              (v3/*: any*/)
+                              (v6/*:: as any*/),
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -364,7 +363,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v5/*: any*/)
+                  (v5/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -408,7 +407,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "filters": [
           "query",
           "type"

--- a/packages/ui/components/__generated__/mentionedPrList_search.graphql.ts
+++ b/packages/ui/components/__generated__/mentionedPrList_search.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<a2a57a265785a7e83e0efc2d7bb96692>>
+ * @generated SignedSource<<64ba0564dc84c4674682d57186ee2483>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -15,7 +14,9 @@ export type mentionedPrList_search$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id?: string;
-        readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        readonly pr_pullRequest?: {
+          readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        } | null | undefined;
       } | null | undefined;
     } | null | undefined> | null | undefined;
   };
@@ -52,7 +53,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       }
     ],
     "refetch": {
@@ -62,7 +63,7 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       },
       "fragmentPathInResult": [],
       "operation": MentionedPrListPaginationQuery_graphql
@@ -118,8 +119,19 @@ return {
                         "storageKey": null
                       },
                       {
-                        "args": null,
-                        "kind": "FragmentSpread",
+                        "fragment": {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "args": null,
+                              "kind": "FragmentSpread",
+                              "name": "pr_pullRequest"
+                            }
+                          ],
+                          "type": "PullRequest",
+                          "abstractKey": null
+                        },
+                        "kind": "AliasedInlineFragmentSpread",
                         "name": "pr_pullRequest"
                       }
                     ],
@@ -182,6 +194,6 @@ return {
 };
 })();
 
-(node as any).hash = "44e3728aec3a584607c7a7658294d809";
+(node as any).hash = "86f4199fc922228f199f9672a95366d5";
 
 export default node;

--- a/packages/ui/components/__generated__/myPrListQuery.graphql.ts
+++ b/packages/ui/components/__generated__/myPrListQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<baceb97675ef0e182332177d05c20057>>
+ * @generated SignedSource<<b91c203427fa1c421126af75d1924351>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -26,7 +25,7 @@ var v0 = {
   "value": 10
 },
 v1 = [
-  (v0/*: any*/),
+  (v0/*:: as any*/),
   {
     "kind": "Literal",
     "name": "query",
@@ -62,7 +61,7 @@ v4 = {
 v5 = {
   "kind": "InlineFragment",
   "selections": [
-    (v3/*: any*/)
+    (v3/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -75,17 +74,17 @@ v6 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/)
+    (v2/*:: as any*/),
+    (v4/*:: as any*/),
+    (v5/*:: as any*/)
   ],
   "storageKey": null
 },
 v7 = [
-  (v0/*: any*/)
+  (v0/*:: as any*/)
 ],
 v8 = [
-  (v4/*: any*/)
+  (v4/*:: as any*/)
 ];
 return {
   "fragment": {
@@ -111,7 +110,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -133,12 +132,12 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
-                      (v6/*: any*/),
+                      (v3/*:: as any*/),
+                      (v6/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -196,7 +195,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -264,13 +263,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -292,10 +291,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
+                                  (v2/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -315,21 +314,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -338,7 +337,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -352,8 +351,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v6/*: any*/),
-                              (v3/*: any*/)
+                              (v6/*:: as any*/),
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -364,7 +363,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v5/*: any*/)
+                  (v5/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -408,7 +407,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "filters": [
           "query",
           "type"

--- a/packages/ui/components/__generated__/myPrList_search.graphql.ts
+++ b/packages/ui/components/__generated__/myPrList_search.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<9483ee4f63264b3351e0d77e9c78ae5b>>
+ * @generated SignedSource<<90e68f3ecb69d256c329305ff43faafc>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -15,7 +14,9 @@ export type myPrList_search$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id?: string;
-        readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        readonly pr_pullRequest?: {
+          readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        } | null | undefined;
       } | null | undefined;
     } | null | undefined> | null | undefined;
   };
@@ -52,7 +53,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       }
     ],
     "refetch": {
@@ -62,7 +63,7 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       },
       "fragmentPathInResult": [],
       "operation": MyPrListPaginationQuery_graphql
@@ -118,8 +119,19 @@ return {
                         "storageKey": null
                       },
                       {
-                        "args": null,
-                        "kind": "FragmentSpread",
+                        "fragment": {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "args": null,
+                              "kind": "FragmentSpread",
+                              "name": "pr_pullRequest"
+                            }
+                          ],
+                          "type": "PullRequest",
+                          "abstractKey": null
+                        },
+                        "kind": "AliasedInlineFragmentSpread",
                         "name": "pr_pullRequest"
                       }
                     ],
@@ -182,6 +194,6 @@ return {
 };
 })();
 
-(node as any).hash = "8e8d3e0fe7b7e21366d69c11aaf5f763";
+(node as any).hash = "d2cd64f6c9d57770504f6f0e28b988de";
 
 export default node;

--- a/packages/ui/components/__generated__/prStatus_pullRequest.graphql.ts
+++ b/packages/ui/components/__generated__/prStatus_pullRequest.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<8d646613bf0166eba403111cbba16ecb>>
+ * @generated SignedSource<<947d5e8f9b4184423e973a29557c3235>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */

--- a/packages/ui/components/__generated__/pr_pullRequest.graphql.ts
+++ b/packages/ui/components/__generated__/pr_pullRequest.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<2c2b4017d1d7dee0c78f8445c7589b4a>>
+ * @generated SignedSource<<88c7a6610d4daf0bb53825325e7852dd>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */

--- a/packages/ui/components/__generated__/repoPrListQuery.graphql.ts
+++ b/packages/ui/components/__generated__/repoPrListQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<1c0158dab7c765064c6a31b991e8e0f2>>
+ * @generated SignedSource<<38067275769da337870fbb21b9236f07>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -40,8 +39,8 @@ v2 = {
   "value": 10
 },
 v3 = [
-  (v2/*: any*/),
-  (v1/*: any*/),
+  (v2/*:: as any*/),
+  (v1/*:: as any*/),
   {
     "kind": "Literal",
     "name": "type",
@@ -72,7 +71,7 @@ v6 = {
 v7 = {
   "kind": "InlineFragment",
   "selections": [
-    (v5/*: any*/)
+    (v5/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -85,28 +84,28 @@ v8 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v4/*: any*/),
-    (v6/*: any*/),
-    (v7/*: any*/)
+    (v4/*:: as any*/),
+    (v6/*:: as any*/),
+    (v7/*:: as any*/)
   ],
   "storageKey": null
 },
 v9 = [
-  (v2/*: any*/)
+  (v2/*:: as any*/)
 ],
 v10 = [
-  (v6/*: any*/)
+  (v6/*:: as any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "repoPrListQuery",
     "selections": [
       {
         "args": [
-          (v1/*: any*/)
+          (v1/*:: as any*/)
         ],
         "kind": "FragmentSpread",
         "name": "repoPrList_search"
@@ -117,13 +116,13 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
     "name": "repoPrListQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v3/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -145,11 +144,11 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v4/*: any*/),
+                  (v4/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v5/*: any*/),
+                      (v5/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -157,7 +156,7 @@ return {
                         "name": "mergedAt",
                         "storageKey": null
                       },
-                      (v8/*: any*/),
+                      (v8/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -208,7 +207,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v5/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -276,13 +275,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v5/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v9/*: any*/),
+                        "args": (v9/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -304,10 +303,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v4/*: any*/),
+                                  (v4/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v10/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -327,21 +326,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v10/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v10/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v7/*: any*/)
+                                  (v7/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v5/*: any*/)
+                              (v5/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -350,7 +349,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v9/*: any*/),
+                        "args": (v9/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -364,8 +363,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v8/*: any*/),
-                              (v5/*: any*/)
+                              (v8/*:: as any*/),
+                              (v5/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -376,7 +375,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v7/*: any*/)
+                  (v7/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -420,7 +419,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v3/*:: as any*/),
         "filters": [
           "query",
           "type"

--- a/packages/ui/components/__generated__/repoPrList_search.graphql.ts
+++ b/packages/ui/components/__generated__/repoPrList_search.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<0723ff3e390641e3d49d6026c4ff1fc0>>
+ * @generated SignedSource<<3d7d97cc5bda83c1cf6dead0ce29ce96>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -16,7 +15,9 @@ export type repoPrList_search$data = {
       readonly node: {
         readonly id?: string;
         readonly mergedAt?: any | null | undefined;
-        readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        readonly pr_pullRequest?: {
+          readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        } | null | undefined;
       } | null | undefined;
     } | null | undefined> | null | undefined;
   };
@@ -58,7 +59,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       }
     ],
     "refetch": {
@@ -68,7 +69,7 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       },
       "fragmentPathInResult": [],
       "operation": RepoPrListPaginationQuery_graphql
@@ -131,8 +132,19 @@ return {
                         "storageKey": null
                       },
                       {
-                        "args": null,
-                        "kind": "FragmentSpread",
+                        "fragment": {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "args": null,
+                              "kind": "FragmentSpread",
+                              "name": "pr_pullRequest"
+                            }
+                          ],
+                          "type": "PullRequest",
+                          "abstractKey": null
+                        },
+                        "kind": "AliasedInlineFragmentSpread",
                         "name": "pr_pullRequest"
                       }
                     ],
@@ -195,6 +207,6 @@ return {
 };
 })();
 
-(node as any).hash = "bc2a0d6e1b13ad0dcc57eabfb9cca4c5";
+(node as any).hash = "e9bac8e6e45ab8637d0a02da65560412";
 
 export default node;

--- a/packages/ui/components/__generated__/reviewPrListQuery.graphql.ts
+++ b/packages/ui/components/__generated__/reviewPrListQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<7dc4c818dcc2f0c12c3705bb2a4803f2>>
+ * @generated SignedSource<<a4eeed5fa39c9a6e734a640bab2a5d2c>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -26,7 +25,7 @@ var v0 = {
   "value": 10
 },
 v1 = [
-  (v0/*: any*/),
+  (v0/*:: as any*/),
   {
     "kind": "Literal",
     "name": "query",
@@ -62,7 +61,7 @@ v4 = {
 v5 = {
   "kind": "InlineFragment",
   "selections": [
-    (v3/*: any*/)
+    (v3/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -75,17 +74,17 @@ v6 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v2/*: any*/),
-    (v4/*: any*/),
-    (v5/*: any*/)
+    (v2/*:: as any*/),
+    (v4/*:: as any*/),
+    (v5/*:: as any*/)
   ],
   "storageKey": null
 },
 v7 = [
-  (v0/*: any*/)
+  (v0/*:: as any*/)
 ],
 v8 = [
-  (v4/*: any*/)
+  (v4/*:: as any*/)
 ];
 return {
   "fragment": {
@@ -111,7 +110,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -133,11 +132,11 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
+                  (v2/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v3/*: any*/),
+                      (v3/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -145,7 +144,7 @@ return {
                         "name": "reviewDecision",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v6/*:: as any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -203,7 +202,7 @@ return {
                             "name": "nameWithOwner",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
@@ -264,13 +263,13 @@ return {
                             "name": "state",
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v3/*:: as any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "ReviewRequestConnection",
                         "kind": "LinkedField",
                         "name": "reviewRequests",
@@ -292,10 +291,10 @@ return {
                                 "name": "requestedReviewer",
                                 "plural": false,
                                 "selections": [
-                                  (v2/*: any*/),
+                                  (v2/*:: as any*/),
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "User",
                                     "abstractKey": null
                                   },
@@ -315,21 +314,21 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Bot",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v8/*:: as any*/),
                                     "type": "Mannequin",
                                     "abstractKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v5/*:: as any*/)
                                 ],
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -338,7 +337,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v7/*:: as any*/),
                         "concreteType": "PullRequestReviewConnection",
                         "kind": "LinkedField",
                         "name": "reviews",
@@ -352,8 +351,8 @@ return {
                             "name": "nodes",
                             "plural": true,
                             "selections": [
-                              (v6/*: any*/),
-                              (v3/*: any*/)
+                              (v6/*:: as any*/),
+                              (v3/*:: as any*/)
                             ],
                             "storageKey": null
                           }
@@ -364,7 +363,7 @@ return {
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v5/*: any*/)
+                  (v5/*:: as any*/)
                 ],
                 "storageKey": null
               },
@@ -408,7 +407,7 @@ return {
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v1/*:: as any*/),
         "filters": [
           "query",
           "type"

--- a/packages/ui/components/__generated__/reviewPrList_search.graphql.ts
+++ b/packages/ui/components/__generated__/reviewPrList_search.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<24d48d8f32f9519387b61159173e6c64>>
+ * @generated SignedSource<<64ea5a5047b2714b80fbb845be373981>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -16,8 +15,10 @@ export type reviewPrList_search$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id?: string;
+        readonly pr_pullRequest?: {
+          readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        } | null | undefined;
         readonly reviewDecision?: PullRequestReviewDecision | null | undefined;
-        readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
       } | null | undefined;
     } | null | undefined> | null | undefined;
   };
@@ -54,7 +55,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       }
     ],
     "refetch": {
@@ -64,7 +65,7 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       },
       "fragmentPathInResult": [],
       "operation": ReviewPrListPaginationQuery_graphql
@@ -127,8 +128,19 @@ return {
                         "storageKey": null
                       },
                       {
-                        "args": null,
-                        "kind": "FragmentSpread",
+                        "fragment": {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "args": null,
+                              "kind": "FragmentSpread",
+                              "name": "pr_pullRequest"
+                            }
+                          ],
+                          "type": "PullRequest",
+                          "abstractKey": null
+                        },
+                        "kind": "AliasedInlineFragmentSpread",
                         "name": "pr_pullRequest"
                       }
                     ],
@@ -191,6 +203,6 @@ return {
 };
 })();
 
-(node as any).hash = "a847f9c12f3de69700c665003aa96d4a";
+(node as any).hash = "47a5275434b550171444688b14730bad";
 
 export default node;

--- a/packages/ui/components/__generated__/reviewedPrListQuery.graphql.ts
+++ b/packages/ui/components/__generated__/reviewedPrListQuery.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<400e51f3ac2268ba3472ae242bed2689>>
+ * @generated SignedSource<<fceda3742b19f880b1125249470aeb76>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -31,13 +30,13 @@ v1 = {
   "value": "ISSUE"
 },
 v2 = [
-  (v0/*: any*/),
+  (v0/*:: as any*/),
   {
     "kind": "Literal",
     "name": "query",
     "value": "-author:@me -is:draft is:open is:pr reviewed-by:@me -review:approved sort:updated"
   },
-  (v1/*: any*/)
+  (v1/*:: as any*/)
 ],
 v3 = {
   "alias": null,
@@ -63,7 +62,7 @@ v5 = {
 v6 = {
   "kind": "InlineFragment",
   "selections": [
-    (v4/*: any*/)
+    (v4/*:: as any*/)
   ],
   "type": "Node",
   "abstractKey": "__isNode"
@@ -76,9 +75,9 @@ v7 = {
   "name": "author",
   "plural": false,
   "selections": [
-    (v3/*: any*/),
-    (v5/*: any*/),
-    (v6/*: any*/)
+    (v3/*:: as any*/),
+    (v5/*:: as any*/),
+    (v6/*:: as any*/)
   ],
   "storageKey": null
 },
@@ -139,7 +138,7 @@ v14 = {
       "name": "nameWithOwner",
       "storageKey": null
     },
-    (v4/*: any*/)
+    (v4/*:: as any*/)
   ],
   "storageKey": null
 },
@@ -207,19 +206,19 @@ v22 = {
       "name": "state",
       "storageKey": null
     },
-    (v4/*: any*/)
+    (v4/*:: as any*/)
   ],
   "storageKey": null
 },
 v23 = [
-  (v0/*: any*/)
+  (v0/*:: as any*/)
 ],
 v24 = [
-  (v5/*: any*/)
+  (v5/*:: as any*/)
 ],
 v25 = {
   "alias": null,
-  "args": (v23/*: any*/),
+  "args": (v23/*:: as any*/),
   "concreteType": "ReviewRequestConnection",
   "kind": "LinkedField",
   "name": "reviewRequests",
@@ -241,10 +240,10 @@ v25 = {
           "name": "requestedReviewer",
           "plural": false,
           "selections": [
-            (v3/*: any*/),
+            (v3/*:: as any*/),
             {
               "kind": "InlineFragment",
-              "selections": (v24/*: any*/),
+              "selections": (v24/*:: as any*/),
               "type": "User",
               "abstractKey": null
             },
@@ -264,21 +263,21 @@ v25 = {
             },
             {
               "kind": "InlineFragment",
-              "selections": (v24/*: any*/),
+              "selections": (v24/*:: as any*/),
               "type": "Bot",
               "abstractKey": null
             },
             {
               "kind": "InlineFragment",
-              "selections": (v24/*: any*/),
+              "selections": (v24/*:: as any*/),
               "type": "Mannequin",
               "abstractKey": null
             },
-            (v6/*: any*/)
+            (v6/*:: as any*/)
           ],
           "storageKey": null
         },
-        (v4/*: any*/)
+        (v4/*:: as any*/)
       ],
       "storageKey": null
     }
@@ -287,7 +286,7 @@ v25 = {
 },
 v26 = {
   "alias": null,
-  "args": (v23/*: any*/),
+  "args": (v23/*:: as any*/),
   "concreteType": "PullRequestReviewConnection",
   "kind": "LinkedField",
   "name": "reviews",
@@ -301,8 +300,8 @@ v26 = {
       "name": "nodes",
       "plural": true,
       "selections": [
-        (v7/*: any*/),
-        (v4/*: any*/)
+        (v7/*:: as any*/),
+        (v4/*:: as any*/)
       ],
       "storageKey": null
     }
@@ -346,13 +345,13 @@ v29 = [
   "type"
 ],
 v30 = [
-  (v0/*: any*/),
+  (v0/*:: as any*/),
   {
     "kind": "Literal",
     "name": "query",
     "value": "-author:@me -is:draft is:open is:pr review-requested:@me sort:updated"
   },
-  (v1/*: any*/)
+  (v1/*:: as any*/)
 ];
 return {
   "fragment": {
@@ -383,7 +382,7 @@ return {
     "selections": [
       {
         "alias": "reviewed",
-        "args": (v2/*: any*/),
+        "args": (v2/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -405,49 +404,49 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/),
+                  (v3/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v4/*: any*/),
-                      (v7/*: any*/),
-                      (v8/*: any*/),
-                      (v9/*: any*/),
-                      (v10/*: any*/),
-                      (v11/*: any*/),
-                      (v12/*: any*/),
-                      (v13/*: any*/),
-                      (v14/*: any*/),
-                      (v15/*: any*/),
-                      (v16/*: any*/),
-                      (v17/*: any*/),
-                      (v18/*: any*/),
-                      (v19/*: any*/),
-                      (v20/*: any*/),
-                      (v21/*: any*/),
-                      (v22/*: any*/),
-                      (v25/*: any*/),
-                      (v26/*: any*/)
+                      (v4/*:: as any*/),
+                      (v7/*:: as any*/),
+                      (v8/*:: as any*/),
+                      (v9/*:: as any*/),
+                      (v10/*:: as any*/),
+                      (v11/*:: as any*/),
+                      (v12/*:: as any*/),
+                      (v13/*:: as any*/),
+                      (v14/*:: as any*/),
+                      (v15/*:: as any*/),
+                      (v16/*:: as any*/),
+                      (v17/*:: as any*/),
+                      (v18/*:: as any*/),
+                      (v19/*:: as any*/),
+                      (v20/*:: as any*/),
+                      (v21/*:: as any*/),
+                      (v22/*:: as any*/),
+                      (v25/*:: as any*/),
+                      (v26/*:: as any*/)
                     ],
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v6/*: any*/)
+                  (v6/*:: as any*/)
                 ],
                 "storageKey": null
               },
-              (v27/*: any*/)
+              (v27/*:: as any*/)
             ],
             "storageKey": null
           },
-          (v28/*: any*/)
+          (v28/*:: as any*/)
         ],
         "storageKey": "search(first:10,query:\"-author:@me -is:draft is:open is:pr reviewed-by:@me -review:approved sort:updated\",type:\"ISSUE\")"
       },
       {
         "alias": "reviewed",
-        "args": (v2/*: any*/),
-        "filters": (v29/*: any*/),
+        "args": (v2/*:: as any*/),
+        "filters": (v29/*:: as any*/),
         "handle": "connection",
         "key": "reviewedPrList_reviewed",
         "kind": "LinkedHandle",
@@ -455,7 +454,7 @@ return {
       },
       {
         "alias": "changesRequested",
-        "args": (v30/*: any*/),
+        "args": (v30/*:: as any*/),
         "concreteType": "SearchResultItemConnection",
         "kind": "LinkedField",
         "name": "search",
@@ -477,49 +476,49 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/),
+                  (v3/*:: as any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v4/*: any*/),
-                      (v15/*: any*/),
-                      (v7/*: any*/),
-                      (v8/*: any*/),
-                      (v9/*: any*/),
-                      (v10/*: any*/),
-                      (v11/*: any*/),
-                      (v12/*: any*/),
-                      (v13/*: any*/),
-                      (v14/*: any*/),
-                      (v16/*: any*/),
-                      (v17/*: any*/),
-                      (v18/*: any*/),
-                      (v19/*: any*/),
-                      (v20/*: any*/),
-                      (v21/*: any*/),
-                      (v22/*: any*/),
-                      (v25/*: any*/),
-                      (v26/*: any*/)
+                      (v4/*:: as any*/),
+                      (v15/*:: as any*/),
+                      (v7/*:: as any*/),
+                      (v8/*:: as any*/),
+                      (v9/*:: as any*/),
+                      (v10/*:: as any*/),
+                      (v11/*:: as any*/),
+                      (v12/*:: as any*/),
+                      (v13/*:: as any*/),
+                      (v14/*:: as any*/),
+                      (v16/*:: as any*/),
+                      (v17/*:: as any*/),
+                      (v18/*:: as any*/),
+                      (v19/*:: as any*/),
+                      (v20/*:: as any*/),
+                      (v21/*:: as any*/),
+                      (v22/*:: as any*/),
+                      (v25/*:: as any*/),
+                      (v26/*:: as any*/)
                     ],
                     "type": "PullRequest",
                     "abstractKey": null
                   },
-                  (v6/*: any*/)
+                  (v6/*:: as any*/)
                 ],
                 "storageKey": null
               },
-              (v27/*: any*/)
+              (v27/*:: as any*/)
             ],
             "storageKey": null
           },
-          (v28/*: any*/)
+          (v28/*:: as any*/)
         ],
         "storageKey": "search(first:10,query:\"-author:@me -is:draft is:open is:pr review-requested:@me sort:updated\",type:\"ISSUE\")"
       },
       {
         "alias": "changesRequested",
-        "args": (v30/*: any*/),
-        "filters": (v29/*: any*/),
+        "args": (v30/*:: as any*/),
+        "filters": (v29/*:: as any*/),
         "handle": "connection",
         "key": "reviewedPrList_changesRequested",
         "kind": "LinkedHandle",

--- a/packages/ui/components/__generated__/reviewedPrList_changesRequested.graphql.ts
+++ b/packages/ui/components/__generated__/reviewedPrList_changesRequested.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<89ce679fdbc1e16ababe8b8833c4609a>>
+ * @generated SignedSource<<726bde3c7f4bc2d90522884abf693101>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -16,8 +15,10 @@ export type reviewedPrList_changesRequested$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id?: string;
+        readonly pr_pullRequest?: {
+          readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        } | null | undefined;
         readonly reviewDecision?: PullRequestReviewDecision | null | undefined;
-        readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
       } | null | undefined;
     } | null | undefined> | null | undefined;
   };
@@ -54,7 +55,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       }
     ],
     "refetch": {
@@ -64,7 +65,7 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       },
       "fragmentPathInResult": [],
       "operation": ReviewedPrListChangesRequestedPaginationQuery_graphql
@@ -127,8 +128,19 @@ return {
                         "storageKey": null
                       },
                       {
-                        "args": null,
-                        "kind": "FragmentSpread",
+                        "fragment": {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "args": null,
+                              "kind": "FragmentSpread",
+                              "name": "pr_pullRequest"
+                            }
+                          ],
+                          "type": "PullRequest",
+                          "abstractKey": null
+                        },
+                        "kind": "AliasedInlineFragmentSpread",
                         "name": "pr_pullRequest"
                       }
                     ],
@@ -191,6 +203,6 @@ return {
 };
 })();
 
-(node as any).hash = "e5f626be75366815c23fcf78887dd5e1";
+(node as any).hash = "6cf1be154913ca8fffee1d7bf2faf6e1";
 
 export default node;

--- a/packages/ui/components/__generated__/reviewedPrList_reviewed.graphql.ts
+++ b/packages/ui/components/__generated__/reviewedPrList_reviewed.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<fbdf5c112c57480b9954b7c05218770a>>
+ * @generated SignedSource<<64b5e9acea9535c94ded8b46950ebbfe>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -15,7 +14,9 @@ export type reviewedPrList_reviewed$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly id?: string;
-        readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        readonly pr_pullRequest?: {
+          readonly " $fragmentSpreads": FragmentRefs<"pr_pullRequest">;
+        } | null | undefined;
       } | null | undefined;
     } | null | undefined> | null | undefined;
   };
@@ -52,7 +53,7 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       }
     ],
     "refetch": {
@@ -62,7 +63,7 @@ return {
           "cursor": "cursor"
         },
         "backward": null,
-        "path": (v0/*: any*/)
+        "path": (v0/*:: as any*/)
       },
       "fragmentPathInResult": [],
       "operation": ReviewedPrListPaginationQuery_graphql
@@ -118,8 +119,19 @@ return {
                         "storageKey": null
                       },
                       {
-                        "args": null,
-                        "kind": "FragmentSpread",
+                        "fragment": {
+                          "kind": "InlineFragment",
+                          "selections": [
+                            {
+                              "args": null,
+                              "kind": "FragmentSpread",
+                              "name": "pr_pullRequest"
+                            }
+                          ],
+                          "type": "PullRequest",
+                          "abstractKey": null
+                        },
+                        "kind": "AliasedInlineFragmentSpread",
                         "name": "pr_pullRequest"
                       }
                     ],
@@ -182,6 +194,6 @@ return {
 };
 })();
 
-(node as any).hash = "1262404a387032481886101252e8017c";
+(node as any).hash = "9d1a3d003e081b60888470ca40e84ab4";
 
 export default node;

--- a/packages/ui/components/__generated__/reviewerAvatars_pullRequest.graphql.ts
+++ b/packages/ui/components/__generated__/reviewerAvatars_pullRequest.graphql.ts
@@ -1,7 +1,6 @@
 /**
- * @generated SignedSource<<8e40318c5485ef155ef05a81ce429907>>
+ * @generated SignedSource<<98eaa10f7ea0e8dad15012390f675dd3>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* tslint:disable */
@@ -53,7 +52,7 @@ v1 = {
   "kind": "LinkedField",
   "name": "author",
   "plural": false,
-  "selections": (v0/*: any*/),
+  "selections": (v0/*:: as any*/),
   "storageKey": null
 },
 v2 = [
@@ -71,14 +70,14 @@ return {
   "selections": [
     {
       "kind": "RequiredField",
-      "field": (v1/*: any*/),
+      "field": (v1/*:: as any*/),
       "action": "THROW"
     },
     {
       "kind": "RequiredField",
       "field": {
         "alias": null,
-        "args": (v2/*: any*/),
+        "args": (v2/*:: as any*/),
         "concreteType": "ReviewRequestConnection",
         "kind": "LinkedField",
         "name": "reviewRequests",
@@ -104,7 +103,7 @@ return {
                   "selections": [
                     {
                       "kind": "InlineFragment",
-                      "selections": (v0/*: any*/),
+                      "selections": (v0/*:: as any*/),
                       "type": "User",
                       "abstractKey": null
                     },
@@ -124,13 +123,13 @@ return {
                     },
                     {
                       "kind": "InlineFragment",
-                      "selections": (v0/*: any*/),
+                      "selections": (v0/*:: as any*/),
                       "type": "Bot",
                       "abstractKey": null
                     },
                     {
                       "kind": "InlineFragment",
-                      "selections": (v0/*: any*/),
+                      "selections": (v0/*:: as any*/),
                       "type": "Mannequin",
                       "abstractKey": null
                     }
@@ -149,7 +148,7 @@ return {
     },
     {
       "alias": null,
-      "args": (v2/*: any*/),
+      "args": (v2/*:: as any*/),
       "concreteType": "PullRequestReviewConnection",
       "kind": "LinkedField",
       "name": "reviews",
@@ -165,7 +164,7 @@ return {
             "name": "nodes",
             "plural": true,
             "selections": [
-              (v1/*: any*/)
+              (v1/*:: as any*/)
             ],
             "storageKey": null
           },

--- a/packages/ui/components/mentioned-pr-list.tsx
+++ b/packages/ui/components/mentioned-pr-list.tsx
@@ -50,7 +50,7 @@ export const MentionedPrList = ({ queryRef }: Props) => {
             node {
               ... on PullRequest {
                 id
-                ...pr_pullRequest
+                ...pr_pullRequest @alias
               }
             }
           }
@@ -65,7 +65,7 @@ export const MentionedPrList = ({ queryRef }: Props) => {
       {nonnull(search.edges)
         .map(({ node }) => node)
         .map((pr) => (
-          <Pr key={pr!.id} prKey={pr!} />
+          <Pr key={pr!.id} prKey={pr!.pr_pullRequest!} />
         ))}
       {hasNext && (
         <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />

--- a/packages/ui/components/my-pr-list.tsx
+++ b/packages/ui/components/my-pr-list.tsx
@@ -44,7 +44,7 @@ export const MyPrList = ({ queryRef }: Props) => {
             node {
               ... on PullRequest {
                 id
-                ...pr_pullRequest
+                ...pr_pullRequest @alias
               }
             }
           }
@@ -59,7 +59,7 @@ export const MyPrList = ({ queryRef }: Props) => {
       {nonnull(search.edges)
         .map(({ node }) => node)
         .map((pr) => (
-          <Pr key={pr!.id} prKey={pr!} />
+          <Pr key={pr!.id} prKey={pr!.pr_pullRequest!} />
         ))}
       {hasNext && (
         <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />

--- a/packages/ui/components/repo-pr-list.tsx
+++ b/packages/ui/components/repo-pr-list.tsx
@@ -44,7 +44,7 @@ export const RepoPrList = ({ queryRef, title }: Props) => {
               ... on PullRequest {
                 id
                 mergedAt
-                ...pr_pullRequest
+                ...pr_pullRequest @alias
               }
             }
           }
@@ -59,7 +59,7 @@ export const RepoPrList = ({ queryRef, title }: Props) => {
       {nonnull(search.edges)
         .sort((a, b) => (a.node!.mergedAt > b.node!.mergedAt ? -1 : 1))
         .map(({ node }) => (
-          <Pr key={node!.id} prKey={node!} />
+          <Pr key={node!.id} prKey={node!.pr_pullRequest!} />
         ))}
       {hasNext && (
         <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />

--- a/packages/ui/components/review-pr-list.tsx
+++ b/packages/ui/components/review-pr-list.tsx
@@ -51,7 +51,7 @@ export const ReviewPrList = ({ queryRef }: Props) => {
               ... on PullRequest {
                 id
                 reviewDecision
-                ...pr_pullRequest
+                ...pr_pullRequest @alias
               }
             }
           }
@@ -73,7 +73,7 @@ export const ReviewPrList = ({ queryRef }: Props) => {
   return (
     <PrList title="Review requested">
       {prs.map((pr) => (
-        <Pr key={pr!.id} prKey={pr!} />
+        <Pr key={pr!.id} prKey={pr!.pr_pullRequest!} />
       ))}
       {hasNext && (
         <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />

--- a/packages/ui/components/reviewed-pr-list.tsx
+++ b/packages/ui/components/reviewed-pr-list.tsx
@@ -55,7 +55,7 @@ export const ReviewedPrList = ({ queryRef }: Props) => {
             node {
               ... on PullRequest {
                 id
-                ...pr_pullRequest
+                ...pr_pullRequest @alias
               }
             }
           }
@@ -95,7 +95,7 @@ export const ReviewedPrList = ({ queryRef }: Props) => {
               ... on PullRequest {
                 id
                 reviewDecision
-                ...pr_pullRequest
+                ...pr_pullRequest @alias
               }
             }
           }
@@ -132,7 +132,7 @@ export const ReviewedPrList = ({ queryRef }: Props) => {
   return (
     <PrList title="Reviewed">
       {allPrs.map((pr) => (
-        <Pr key={pr!.id} prKey={pr!} />
+        <Pr key={pr!.id} prKey={pr!.pr_pullRequest!} />
       ))}
       {hasNext && (
         <LoadMoreButton disabled={isLoadingNext} onClick={loadNext} />

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,21 +12,21 @@
   "dependencies": {
     "@primer/octicons-react": "19.21.1",
     "clsx": "^2.1.1",
-    "graphql": "16.12.0",
-    "react-relay": "20.1.1",
-    "relay-runtime": "20.1.1",
     "tailwind-merge": "^2.4.0"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "graphql": "^16",
+    "react": "^19",
+    "react-dom": "^19",
+    "react-relay": "^21",
+    "relay-runtime": "^21"
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/react-relay": "18.2.1",
-    "@types/relay-runtime": "20.1.0",
+    "@types/relay-runtime": "20.1.1",
     "@typescript-eslint/parser": "8.50.1",
     "eslint": "9.39.2",
     "eslint-import-resolver-typescript": "4.4.4",
@@ -37,12 +37,15 @@
     "eslint-plugin-relay": "2.0.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "4.3.0",
+    "graphql": "16.12.0",
     "prettier": "3.7.4",
     "prettier-plugin-tailwindcss": "0.7.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "relay-compiler": "20.1.1",
-    "typescript": "5.9.3",
+    "react-relay": "21.0.0",
+    "relay-compiler": "21.0.0",
+    "relay-runtime": "21.0.0",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.50.1"
   }
 }

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -17,8 +17,8 @@
     "next": "16.2.5",
     "react": "19.2.6",
     "react-dom": "19.2.6",
-    "react-relay": "20.1.1",
-    "relay-runtime": "20.1.1"
+    "react-relay": "21.0.0",
+    "relay-runtime": "21.0.0"
   },
   "devDependencies": {
     "@eslint/js": "9.39.2",
@@ -43,7 +43,7 @@
     "prettier-plugin-tailwindcss": "0.7.2",
     "server-only": "^0.0.1",
     "tailwindcss": "^3.4.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "typescript-eslint": "8.50.1"
   }
 }


### PR DESCRIPTION
Relay 21 enforces `@alias` on fragment spreads where the parent selection type might not match — the 6 `...pr_pullRequest` spreads inside `... on PullRequest { ... }` failed validation. Added `@alias` to each spread; consumers now pass `pr!.pr_pullRequest!` to `<Pr prKey={...} />` instead of `pr!` directly (the aliased fragment ref is on a nullable property now).

TS 6 dropped automatic loading of every `@types/*` package; `packages/extension/tsconfig.json` needed explicit `types: ["chrome", "vite/client"]` so the chrome extension globals and the `.css` side-effect import in `main.tsx` still resolve.

Also moved `graphql`, `react-relay`, and `relay-runtime` from `@pr-monitor/ui`'s `dependencies` to `peerDependencies`. These are singleton-context libraries (`RelayEnvironmentProvider` etc.); two copies in the workspace would mean fragment reads from `ui` couldn't see providers mounted by `www` or `extension`. The peer declaration makes the contract explicit and prevents accidental version drift.