### PR TITLE
docs: add extension privacy policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 # relay-compiler artifacts
 **/__generated__/
 
+# chrome web store packaging
+packages/extension/*.zip
+
 # production
 /build
 

--- a/packages/extension/PRIVACY.md
+++ b/packages/extension/PRIVACY.md
@@ -1,0 +1,25 @@
+# Privacy Policy
+
+PR Monitor is a personal Chrome extension maintained at [github.com/dbharris2/pr-monitor](https://github.com/dbharris2/pr-monitor).
+
+## What it collects
+
+PR Monitor stores the GitHub personal access token you provide. The token is kept in `chrome.storage.local` on your device only — it is never sent to me or to any third party.
+
+## What it sends off-device
+
+The token is sent only to `https://api.github.com` as an `Authorization` header, in order to fetch the list of pull requests displayed in the popup and to update the toolbar badge count. No other servers are contacted.
+
+## What it doesn't do
+
+- No analytics, no telemetry, no error reporting.
+- No cookies, no tracking, no advertising IDs.
+- The extension never reads, modifies, or has access to any other website.
+
+## Removing your data
+
+Click **Update Token** in the popup and clear the field, or simply remove the extension — everything is stored locally and goes away with it.
+
+## Contact
+
+[dbharris2@gmail.com](mailto:dbharris2@gmail.com)


### PR DESCRIPTION
Required for Chrome Web Store submission since the extension stores a user-supplied GitHub personal access token in `chrome.storage.local`. The CWS form rejects extensions that collect user data without a public privacy policy URL.

Hosted as `packages/extension/PRIVACY.md` and linked from the CWS listing via the GitHub-rendered URL. The policy is intentionally narrow: declares that the token never leaves the user's device except as an `Authorization` header to `api.github.com`, and that there's no analytics, telemetry, or tracking of any kind.

Also gitignored `packages/extension/*.zip` — the file produced by `zip -r ../pr-monitor-extension.zip .` for uploading to the CWS is a build artifact, not source.