### PR TITLE
ci: add build verification + extension release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate Relay artifacts
+        run: bun relay
+
+      - name: Prettier
+        run: bun format:check
+
+      - name: ESLint
+        run: bun lint
+
+      - name: TypeScript
+        run: bun ts
+
+      - name: Build web app
+        run: bun run build
+
+      - name: Build extension
+        run: bun run ext:build

--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -1,0 +1,51 @@
+name: Release Extension
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build extension
+        run: bun run ext:build
+
+      - name: Read manifest version
+        id: ver
+        run: |
+          VERSION=$(jq -r .version packages/extension/manifest.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Guard against duplicate version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="extension-v${{ steps.ver.outputs.version }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::error::A release tagged '$TAG' already exists. Bump 'version' in packages/extension/manifest.json before running."
+            exit 1
+          fi
+
+      - name: Package zip
+        run: |
+          cd packages/extension/dist
+          zip -r ../pr-monitor-extension.zip .
+
+      - name: Create draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: extension-v${{ steps.ver.outputs.version }}
+          name: PR Monitor extension v${{ steps.ver.outputs.version }}
+          files: packages/extension/pr-monitor-extension.zip
+          draft: true
+          fail_on_unmatched_files: true

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ext:build": "bun --filter @pr-monitor/extension build",
     "relay": "bun --filter @pr-monitor/ui relay",
     "format": "bun --filter '*' format",
+    "format:check": "bun --filter '*' format:check",
     "lint": "bun --filter '*' lint",
     "ts": "bun --filter '*' ts"
   }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "prebuild": "bun --filter @pr-monitor/ui relay",
     "format": "prettier . --write",
+    "format:check": "prettier . --check",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 20 --no-warn-ignored",
     "ts": "tsc --pretty --noEmit"
   },

--- a/packages/ui/components/avatar.tsx
+++ b/packages/ui/components/avatar.tsx
@@ -11,7 +11,7 @@ export const Avatar = ({ src, title, className, shape = 'circle' }: Props) => (
   <img
     alt={title}
     className={cn(
-      'size-5 border-2 border-solid border-stone-700 dark:border-catppuccin-subtext0',
+      'dark:border-catppuccin-subtext0 size-5 border-2 border-solid border-stone-700',
       shape === 'circle' ? 'rounded-full' : 'rounded',
       className
     )}

--- a/packages/ui/components/display-mode-toggle.tsx
+++ b/packages/ui/components/display-mode-toggle.tsx
@@ -20,9 +20,9 @@ type IconButtonProps = {
 const IconButton = ({ icon, onClick, selected, title }: IconButtonProps) => (
   <button
     className={cn(
-      'cursor-pointer rounded-md border-none p-1.5 outline-none transition-colors hover:bg-slate-100 dark:text-catppuccin-text dark:hover:bg-catppuccin-surface1',
+      'dark:text-catppuccin-text dark:hover:bg-catppuccin-surface1 cursor-pointer rounded-md border-none p-1.5 transition-colors outline-none hover:bg-slate-100',
       {
-        'bg-slate-200 dark:bg-catppuccin-surface1': selected,
+        'dark:bg-catppuccin-surface1 bg-slate-200': selected,
         'bg-transparent': !selected,
       }
     )}
@@ -38,7 +38,7 @@ export const DisplayModeToggle = () => {
   const { displayMode, setDisplayMode } = useDisplayMode();
 
   return (
-    <div className="flex gap-1 rounded-lg bg-white p-1 dark:bg-catppuccin-surface0">
+    <div className="dark:bg-catppuccin-surface0 flex gap-1 rounded-lg bg-white p-1">
       <IconButton
         icon={<StackIcon size={16} />}
         mode="standard"

--- a/packages/ui/components/load-more-button.tsx
+++ b/packages/ui/components/load-more-button.tsx
@@ -4,9 +4,9 @@ type Props = {
 };
 
 export const LoadMoreButton = ({ onClick, disabled }: Props) => (
-  <div className="w-full rounded-b-lg bg-white p-3 dark:bg-catppuccin-surface0">
+  <div className="dark:bg-catppuccin-surface0 w-full rounded-b-lg bg-white p-3">
     <button
-      className="m-auto flex cursor-pointer items-center rounded-lg border-none bg-slate-200 p-2 outline-none hover:bg-slate-400 active:bg-slate-600 disabled:bg-slate-600 dark:bg-catppuccin-surface1 dark:text-catppuccin-text"
+      className="dark:bg-catppuccin-surface1 dark:text-catppuccin-text m-auto flex cursor-pointer items-center rounded-lg border-none bg-slate-200 p-2 outline-none hover:bg-slate-400 active:bg-slate-600 disabled:bg-slate-600"
       disabled={disabled}
       onClick={onClick}
       type="button"

--- a/packages/ui/components/pill.tsx
+++ b/packages/ui/components/pill.tsx
@@ -14,10 +14,10 @@ export const Pill = ({
   onRemove,
 }: PillProps) => (
   <button
-    className={`flex items-center gap-1 rounded-full px-3 py-1 text-sm text-black hover:bg-slate-300 dark:text-catppuccin-text dark:hover:bg-catppuccin-surface2 ${
+    className={`dark:text-catppuccin-text dark:hover:bg-catppuccin-surface2 flex items-center gap-1 rounded-full px-3 py-1 text-sm text-black hover:bg-slate-300 ${
       selected
-        ? 'bg-slate-300 ring-2 ring-blue-500 dark:bg-catppuccin-surface2 dark:ring-catppuccin-blue'
-        : 'bg-slate-200 dark:bg-catppuccin-surface1'
+        ? 'dark:bg-catppuccin-surface2 dark:ring-catppuccin-blue bg-slate-300 ring-2 ring-blue-500'
+        : 'dark:bg-catppuccin-surface1 bg-slate-200'
     }`}
     onClick={onSelect}
     type="button"
@@ -25,7 +25,7 @@ export const Pill = ({
     <span>{label}</span>
     {onRemove && (
       <span
-        className="ml-1 text-slate-500 hover:text-red-500 dark:text-catppuccin-overlay0 dark:hover:text-catppuccin-red"
+        className="dark:text-catppuccin-overlay0 dark:hover:text-catppuccin-red ml-1 text-slate-500 hover:text-red-500"
         onClick={(e) => {
           e.stopPropagation();
           onRemove();

--- a/packages/ui/components/pr-list.tsx
+++ b/packages/ui/components/pr-list.tsx
@@ -6,7 +6,7 @@ type Props = {
 };
 
 export const PrList = ({ children, title }: Props) => (
-  <div className="flex flex-col gap-2 dark:text-catppuccin-text">
+  <div className="dark:text-catppuccin-text flex flex-col gap-2">
     {title}
     <div className="flex flex-col rounded-lg border border-solid shadow-md">
       {children}

--- a/packages/ui/components/pr-status.tsx
+++ b/packages/ui/components/pr-status.tsx
@@ -36,7 +36,7 @@ const Badge = ({
 }: BadgeProps) => (
   <span
     className={cn(
-      'flex items-center whitespace-nowrap rounded-full bg-gray-600 px-1.5 py-0.5 text-xs font-semibold leading-none text-white',
+      'flex items-center rounded-full bg-gray-600 px-1.5 py-0.5 text-xs leading-none font-semibold whitespace-nowrap text-white',
       {
         'bg-green-600': isApproved,
         'bg-gray-600': isDraft,

--- a/packages/ui/components/pr.tsx
+++ b/packages/ui/components/pr.tsx
@@ -23,11 +23,11 @@ type CompactPrProps = {
 const CompactPr = ({ pr }: CompactPrProps) => (
   <a
     className={cn(
-      'flex cursor-pointer items-center gap-2 border-b border-solid bg-white px-2 py-1 first:rounded-t-lg last:rounded-b-lg last:border-none hover:bg-purple-300 dark:bg-catppuccin-surface0 dark:hover:bg-catppuccin-mauve/50',
+      'dark:bg-catppuccin-surface0 dark:hover:bg-catppuccin-mauve/50 flex cursor-pointer items-center gap-2 border-b border-solid bg-white px-2 py-1 first:rounded-t-lg last:rounded-b-lg last:border-none hover:bg-purple-300',
       {
-        'bg-red-300 dark:bg-catppuccin-red/50':
+        'dark:bg-catppuccin-red/50 bg-red-300':
           pr.reviewDecision === 'CHANGES_REQUESTED',
-        'bg-green-300 dark:bg-catppuccin-green/50':
+        'dark:bg-catppuccin-green/50 bg-green-300':
           pr.reviewDecision === 'APPROVED' && !pr.mergedAt,
       }
     )}
@@ -37,10 +37,10 @@ const CompactPr = ({ pr }: CompactPrProps) => (
     target="_blank"
   >
     <Avatar className="!size-6 shrink-0" src={pr.author?.avatarUrl ?? ''} />
-    <span className="truncate text-sm text-black dark:text-catppuccin-text">
+    <span className="dark:text-catppuccin-text truncate text-sm text-black">
       {pr.title}
     </span>
-    <span className="ml-auto shrink-0 text-xs text-slate-600 dark:text-catppuccin-subtext0">
+    <span className="dark:text-catppuccin-subtext0 ml-auto shrink-0 text-xs text-slate-600">
       <RelativeTime dateString={pr.mergedAt ?? pr.updatedAt} />
     </span>
     <PrStatus prKey={pr} />
@@ -60,11 +60,11 @@ export const Pr = ({ prKey }: Props) => {
   return (
     <a
       className={cn(
-        'flex cursor-pointer border-b border-solid bg-white p-2 first:rounded-t-lg last:rounded-b-lg last:border-none hover:bg-purple-300 dark:bg-catppuccin-surface0 dark:hover:bg-catppuccin-mauve/50',
+        'dark:bg-catppuccin-surface0 dark:hover:bg-catppuccin-mauve/50 flex cursor-pointer border-b border-solid bg-white p-2 first:rounded-t-lg last:rounded-b-lg last:border-none hover:bg-purple-300',
         {
-          'bg-red-300 dark:bg-catppuccin-red/50':
+          'dark:bg-catppuccin-red/50 bg-red-300':
             pr.reviewDecision === 'CHANGES_REQUESTED',
-          'bg-green-300 dark:bg-catppuccin-green/50':
+          'dark:bg-catppuccin-green/50 bg-green-300':
             pr.reviewDecision === 'APPROVED' && !pr.mergedAt,
         }
       )}
@@ -80,7 +80,7 @@ export const Pr = ({ prKey }: Props) => {
       <div className="ml-2 flex min-w-0 flex-1 flex-col">
         <div className="flex justify-between">
           <div className="flex items-center gap-2 overflow-hidden">
-            <div className="truncate text-black dark:text-catppuccin-text">
+            <div className="dark:text-catppuccin-text truncate text-black">
               {pr.title}
             </div>
           </div>
@@ -89,13 +89,13 @@ export const Pr = ({ prKey }: Props) => {
           </div>
         </div>
         <div className="flex justify-between">
-          <div className="flex grow flex-wrap gap-2 text-slate-600 dark:text-catppuccin-subtext0">
+          <div className="dark:text-catppuccin-subtext0 flex grow flex-wrap gap-2 text-slate-600">
             {pr.repository.nameWithOwner} #{pr.number}
             <div className="flex gap-1">
-              <div className="text-green-600 dark:text-catppuccin-green">
+              <div className="dark:text-catppuccin-green text-green-600">
                 +{pr.additions}
               </div>
-              <div className="text-red-600 dark:text-catppuccin-red">
+              <div className="dark:text-catppuccin-red text-red-600">
                 -{pr.deletions}
               </div>
               @{pr.changedFiles}

--- a/packages/ui/components/repo-prs-view.tsx
+++ b/packages/ui/components/repo-prs-view.tsx
@@ -74,7 +74,7 @@ export const RepoPrsView = ({ isLoggedIn }: Props) => {
         }}
       >
         <input
-          className="flex w-full rounded p-2 dark:bg-catppuccin-surface0 dark:text-catppuccin-text"
+          className="dark:bg-catppuccin-surface0 dark:text-catppuccin-text flex w-full rounded p-2"
           defaultValue={repo}
           placeholder="Insert org/repo here..."
           ref={repoRef}

--- a/packages/ui/components/skeleton-list.tsx
+++ b/packages/ui/components/skeleton-list.tsx
@@ -3,14 +3,14 @@ import cn from 'utils/cn';
 const SkeletonLine = ({ className }: { className?: string }) => (
   <div
     className={cn(
-      'animate-pulse rounded bg-slate-200 dark:bg-catppuccin-surface1',
+      'dark:bg-catppuccin-surface1 animate-pulse rounded bg-slate-200',
       className
     )}
   />
 );
 
 const SkeletonPr = () => (
-  <div className="flex w-full flex-col border-b border-solid bg-white p-2 first:rounded-t-lg last:rounded-b-lg last:border-none dark:bg-catppuccin-surface0">
+  <div className="dark:bg-catppuccin-surface0 flex w-full flex-col border-b border-solid bg-white p-2 first:rounded-t-lg last:rounded-b-lg last:border-none">
     <div className="flex w-full flex-col gap-2">
       <div className="flex justify-between">
         <div className="flex w-full items-center gap-2">
@@ -42,7 +42,7 @@ export const SkeletonList = ({
   <>
     {titles.map((title) => (
       <div
-        className="flex flex-col gap-2 dark:text-catppuccin-text"
+        className="dark:text-catppuccin-text flex flex-col gap-2"
         key={title}
       >
         {title}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "format": "prettier . --write",
+    "format:check": "prettier . --check",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 20 --no-warn-ignored",
     "relay": "relay-compiler",
     "ts": "tsc --pretty --noEmit"

--- a/packages/ui/relay.config.json
+++ b/packages/ui/relay.config.json
@@ -2,9 +2,5 @@
   "src": "./components",
   "language": "typescript",
   "schema": "./data/schema.graphql",
-  "excludes": [
-    "**/node_modules/**",
-    "**/__mocks__/**",
-    "**/__generated__/**"
-  ]
+  "excludes": ["**/node_modules/**", "**/__mocks__/**", "**/__generated__/**"]
 }

--- a/packages/www/CLAUDE.md
+++ b/packages/www/CLAUDE.md
@@ -21,4 +21,4 @@ The Next.js web app. Deployed to Vercel at https://pr-monitor-zeta.vercel.app.
 
 ## Vercel
 
-The project's *Root Directory* is set to `packages/www` with "Include files outside of the Root Directory" enabled so the workspace lockfile + `packages/ui` ship to the build. No `vercel.json` — Vercel auto-detects Next.js.
+The project's _Root Directory_ is set to `packages/www` with "Include files outside of the Root Directory" enabled so the workspace lockfile + `packages/ui` ship to the build. No `vercel.json` — Vercel auto-detects Next.js.

--- a/packages/www/README.md
+++ b/packages/www/README.md
@@ -26,4 +26,4 @@ bun run ts
 bun run format
 ```
 
-`prebuild` runs `bun --filter @pr-monitor/ui relay` automatically, so artifacts get generated before `next build` runs — Vercel deploys work out of the box once the project's *Root Directory* is set to `packages/www`.
+`prebuild` runs `bun --filter @pr-monitor/ui relay` automatically, so artifacts get generated before `next build` runs — Vercel deploys work out of the box once the project's _Root Directory_ is set to `packages/www`.

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -8,6 +8,7 @@
     "prebuild": "bun --filter @pr-monitor/ui relay",
     "start": "next start",
     "format": "prettier . --write",
+    "format:check": "prettier . --check",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 20 --no-warn-ignored",
     "ts": "tsc --pretty --noEmit"
   },


### PR DESCRIPTION
Vercel auto-deploys the web app and would catch a regression there, but the extension build had no automation — a PR that broke `bun ext:build` would only be caught the next time someone manually rebuilt. And shipping the extension to the Chrome Web Store meant rebuilding locally and zipping by hand, with no audit trail.

Two workflows under `.github/workflows/`:

- **`ci.yml`** — runs on PRs and pushes to `main`. Installs deps, regenerates Relay artifacts (since they're gitignored), then runs Prettier check, ESLint, TypeScript, the Next build, and the extension build across all three packages.
- **`release-extension.yml`** — manual `workflow_dispatch` only. Builds the extension, reads `version` from `packages/extension/manifest.json`, zips the contents of `dist/` (with `manifest.json` at the root of the zip), and creates a **draft** GitHub Release tagged `extension-v<version>` with the zip attached. A guard step calls `gh release view` first and fails fast with a clear error if a release with that tag already exists, so you can't accidentally re-release the same version without bumping the manifest.

Also added `format:check` scripts (`prettier . --check`) in each package + a root proxy. The existing `format` script writes, which isn't appropriate for CI.