### PR TITLE
refactor: extract pagination + node helpers in PR list components

### DIFF
--- a/packages/ui/components/mentioned-pr-list.tsx
+++ b/packages/ui/components/mentioned-pr-list.tsx
@@ -1,7 +1,10 @@
 import type { PreloadedQuery } from 'react-relay';
 import { graphql, usePaginationFragment, usePreloadedQuery } from 'react-relay';
 
-import type { mentionedPrList_search$key } from 'components/__generated__/mentionedPrList_search.graphql';
+import type {
+  mentionedPrList_search$data,
+  mentionedPrList_search$key,
+} from 'components/__generated__/mentionedPrList_search.graphql';
 import type { MentionedPrListPaginationQuery } from 'components/__generated__/MentionedPrListPaginationQuery.graphql';
 import type { mentionedPrListQuery } from 'components/__generated__/mentionedPrListQuery.graphql';
 import { LoadMoreButton } from 'components/load-more-button';
@@ -16,7 +19,7 @@ export const MentionedPrListQuery = graphql`
 `;
 
 type Props = {
-  queryRef: PreloadedQuery<mentionedPrListQuery, Record<string, unknown>>;
+  queryRef: PreloadedQuery<mentionedPrListQuery>;
 };
 
 export const MentionedPrList = ({ queryRef }: Props) => {
@@ -29,7 +32,23 @@ export const MentionedPrList = ({ queryRef }: Props) => {
     hasNext,
     loadNext,
     isLoadingNext,
-  } = usePaginationFragment<
+  } = usePaginationSearch(data);
+  const nodes = useNodes(search);
+
+  return (
+    <PrList title="Mentions">
+      {nodes.map((pr) => (
+        <Pr key={pr.id} prKey={pr.pr_pullRequest!} />
+      ))}
+      {hasNext && (
+        <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />
+      )}
+    </PrList>
+  );
+};
+
+const usePaginationSearch = (searchKey: mentionedPrList_search$key) =>
+  usePaginationFragment<
     MentionedPrListPaginationQuery,
     mentionedPrList_search$key
   >(
@@ -57,19 +76,8 @@ export const MentionedPrList = ({ queryRef }: Props) => {
         }
       }
     `,
-    data
+    searchKey
   );
 
-  return (
-    <PrList title="Mentions">
-      {nonnull(search.edges)
-        .map(({ node }) => node)
-        .map((pr) => (
-          <Pr key={pr!.id} prKey={pr!.pr_pullRequest!} />
-        ))}
-      {hasNext && (
-        <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />
-      )}
-    </PrList>
-  );
-};
+const useNodes = (search: mentionedPrList_search$data['search']) =>
+  nonnull(search.edges?.map((e) => e?.node));

--- a/packages/ui/components/my-pr-list.tsx
+++ b/packages/ui/components/my-pr-list.tsx
@@ -1,7 +1,10 @@
 import type { PreloadedQuery } from 'react-relay';
 import { graphql, usePaginationFragment, usePreloadedQuery } from 'react-relay';
 
-import type { myPrList_search$key } from 'components/__generated__/myPrList_search.graphql';
+import type {
+  myPrList_search$data,
+  myPrList_search$key,
+} from 'components/__generated__/myPrList_search.graphql';
 import type { MyPrListPaginationQuery } from 'components/__generated__/MyPrListPaginationQuery.graphql';
 import type { myPrListQuery } from 'components/__generated__/myPrListQuery.graphql';
 import { LoadMoreButton } from 'components/load-more-button';
@@ -16,7 +19,7 @@ export const MyPrListQuery = graphql`
 `;
 
 type Props = {
-  queryRef: PreloadedQuery<myPrListQuery, Record<string, unknown>>;
+  queryRef: PreloadedQuery<myPrListQuery>;
 };
 
 export const MyPrList = ({ queryRef }: Props) => {
@@ -26,7 +29,23 @@ export const MyPrList = ({ queryRef }: Props) => {
     hasNext,
     loadNext,
     isLoadingNext,
-  } = usePaginationFragment<MyPrListPaginationQuery, myPrList_search$key>(
+  } = usePaginationSearch(data);
+  const nodes = useNodes(search);
+
+  return (
+    <PrList title="My PRs">
+      {nodes.map((pr) => (
+        <Pr key={pr.id} prKey={pr.pr_pullRequest!} />
+      ))}
+      {hasNext && (
+        <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />
+      )}
+    </PrList>
+  );
+};
+
+const usePaginationSearch = (searchKey: myPrList_search$key) =>
+  usePaginationFragment<MyPrListPaginationQuery, myPrList_search$key>(
     graphql`
       fragment myPrList_search on Query
       @argumentDefinitions(
@@ -51,19 +70,8 @@ export const MyPrList = ({ queryRef }: Props) => {
         }
       }
     `,
-    data
+    searchKey
   );
 
-  return (
-    <PrList title="My PRs">
-      {nonnull(search.edges)
-        .map(({ node }) => node)
-        .map((pr) => (
-          <Pr key={pr!.id} prKey={pr!.pr_pullRequest!} />
-        ))}
-      {hasNext && (
-        <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />
-      )}
-    </PrList>
-  );
-};
+const useNodes = (search: myPrList_search$data['search']) =>
+  nonnull(search.edges?.map((e) => e?.node));

--- a/packages/ui/components/repo-pr-list.tsx
+++ b/packages/ui/components/repo-pr-list.tsx
@@ -1,7 +1,10 @@
 import type { PreloadedQuery } from 'react-relay';
 import { graphql, usePaginationFragment, usePreloadedQuery } from 'react-relay';
 
-import type { repoPrList_search$key } from 'components/__generated__/repoPrList_search.graphql';
+import type {
+  repoPrList_search$data,
+  repoPrList_search$key,
+} from 'components/__generated__/repoPrList_search.graphql';
 import type { RepoPrListPaginationQuery } from 'components/__generated__/RepoPrListPaginationQuery.graphql';
 import type { repoPrListQuery } from 'components/__generated__/repoPrListQuery.graphql';
 import { LoadMoreButton } from 'components/load-more-button';
@@ -16,7 +19,7 @@ export const RepoPrListQuery = graphql`
 `;
 
 type Props = {
-  queryRef: PreloadedQuery<repoPrListQuery, Record<string, unknown>>;
+  queryRef: PreloadedQuery<repoPrListQuery>;
   title: string;
 };
 
@@ -27,7 +30,23 @@ export const RepoPrList = ({ queryRef, title }: Props) => {
     hasNext,
     loadNext,
     isLoadingNext,
-  } = usePaginationFragment<RepoPrListPaginationQuery, repoPrList_search$key>(
+  } = usePaginationSearch(data);
+  const nodes = useSortedNodes(search);
+
+  return (
+    <PrList title={title}>
+      {nodes.map((node) => (
+        <Pr key={node.id} prKey={node.pr_pullRequest!} />
+      ))}
+      {hasNext && (
+        <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />
+      )}
+    </PrList>
+  );
+};
+
+const usePaginationSearch = (searchKey: repoPrList_search$key) =>
+  usePaginationFragment<RepoPrListPaginationQuery, repoPrList_search$key>(
     graphql`
       fragment repoPrList_search on Query
       @argumentDefinitions(
@@ -51,19 +70,10 @@ export const RepoPrList = ({ queryRef, title }: Props) => {
         }
       }
     `,
-    data
+    searchKey
   );
 
-  return (
-    <PrList title={title}>
-      {nonnull(search.edges)
-        .sort((a, b) => (a.node!.mergedAt > b.node!.mergedAt ? -1 : 1))
-        .map(({ node }) => (
-          <Pr key={node!.id} prKey={node!.pr_pullRequest!} />
-        ))}
-      {hasNext && (
-        <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />
-      )}
-    </PrList>
+const useSortedNodes = (search: repoPrList_search$data['search']) =>
+  nonnull(search.edges?.map((e) => e?.node)).sort((a, b) =>
+    a.mergedAt > b.mergedAt ? -1 : 1
   );
-};

--- a/packages/ui/components/review-pr-list.tsx
+++ b/packages/ui/components/review-pr-list.tsx
@@ -1,7 +1,10 @@
 import type { PreloadedQuery } from 'react-relay';
 import { graphql, usePaginationFragment, usePreloadedQuery } from 'react-relay';
 
-import type { reviewPrList_search$key } from 'components/__generated__/reviewPrList_search.graphql';
+import type {
+  reviewPrList_search$data,
+  reviewPrList_search$key,
+} from 'components/__generated__/reviewPrList_search.graphql';
 import type { ReviewPrListPaginationQuery } from 'components/__generated__/ReviewPrListPaginationQuery.graphql';
 import type { reviewPrListQuery } from 'components/__generated__/reviewPrListQuery.graphql';
 import { LoadMoreButton } from 'components/load-more-button';
@@ -16,7 +19,7 @@ export const ReviewPrListQuery = graphql`
 `;
 
 type Props = {
-  queryRef: PreloadedQuery<reviewPrListQuery, Record<string, unknown>>;
+  queryRef: PreloadedQuery<reviewPrListQuery>;
 };
 
 export const ReviewPrList = ({ queryRef }: Props) => {
@@ -29,10 +32,23 @@ export const ReviewPrList = ({ queryRef }: Props) => {
     hasNext,
     loadNext,
     isLoadingNext,
-  } = usePaginationFragment<
-    ReviewPrListPaginationQuery,
-    reviewPrList_search$key
-  >(
+  } = usePaginationSearch(data);
+  const nodes = useAwaitingReviewNodes(search);
+
+  return (
+    <PrList title="Review requested">
+      {nodes.map((pr) => (
+        <Pr key={pr.id} prKey={pr.pr_pullRequest!} />
+      ))}
+      {hasNext && (
+        <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />
+      )}
+    </PrList>
+  );
+};
+
+const usePaginationSearch = (searchKey: reviewPrList_search$key) =>
+  usePaginationFragment<ReviewPrListPaginationQuery, reviewPrList_search$key>(
     graphql`
       fragment reviewPrList_search on Query
       @argumentDefinitions(
@@ -58,26 +74,13 @@ export const ReviewPrList = ({ queryRef }: Props) => {
         }
       }
     `,
-    data
+    searchKey
   );
 
-  // Filter out PRs that are approved or have changes requested (matches Mac app behavior)
-  const prs = nonnull(search.edges)
-    .map(({ node }) => node)
-    .filter(
-      (pr) =>
-        pr?.reviewDecision !== 'APPROVED' &&
-        pr?.reviewDecision !== 'CHANGES_REQUESTED'
-    );
-
-  return (
-    <PrList title="Review requested">
-      {prs.map((pr) => (
-        <Pr key={pr!.id} prKey={pr!.pr_pullRequest!} />
-      ))}
-      {hasNext && (
-        <LoadMoreButton disabled={isLoadingNext} onClick={() => loadNext(10)} />
-      )}
-    </PrList>
+// Exclude PRs already approved or with changes requested (matches Mac app behavior)
+const useAwaitingReviewNodes = (search: reviewPrList_search$data['search']) =>
+  nonnull(search.edges?.map((e) => e?.node)).filter(
+    (pr) =>
+      pr.reviewDecision !== 'APPROVED' &&
+      pr.reviewDecision !== 'CHANGES_REQUESTED'
   );
-};

--- a/packages/ui/components/reviewed-pr-list.tsx
+++ b/packages/ui/components/reviewed-pr-list.tsx
@@ -1,8 +1,14 @@
 import type { PreloadedQuery } from 'react-relay';
 import { graphql, usePaginationFragment, usePreloadedQuery } from 'react-relay';
 
-import type { reviewedPrList_changesRequested$key } from 'components/__generated__/reviewedPrList_changesRequested.graphql';
-import type { reviewedPrList_reviewed$key } from 'components/__generated__/reviewedPrList_reviewed.graphql';
+import type {
+  reviewedPrList_changesRequested$data,
+  reviewedPrList_changesRequested$key,
+} from 'components/__generated__/reviewedPrList_changesRequested.graphql';
+import type {
+  reviewedPrList_reviewed$data,
+  reviewedPrList_reviewed$key,
+} from 'components/__generated__/reviewedPrList_reviewed.graphql';
 import type { ReviewedPrListChangesRequestedPaginationQuery } from 'components/__generated__/ReviewedPrListChangesRequestedPaginationQuery.graphql';
 import type { ReviewedPrListPaginationQuery } from 'components/__generated__/ReviewedPrListPaginationQuery.graphql';
 import type { reviewedPrListQuery } from 'components/__generated__/reviewedPrListQuery.graphql';
@@ -19,7 +25,7 @@ export const ReviewedPrListQuery = graphql`
 `;
 
 type Props = {
-  queryRef: PreloadedQuery<reviewedPrListQuery, Record<string, unknown>>;
+  queryRef: PreloadedQuery<reviewedPrListQuery>;
 };
 
 export const ReviewedPrList = ({ queryRef }: Props) => {
@@ -28,13 +34,44 @@ export const ReviewedPrList = ({ queryRef }: Props) => {
     queryRef
   );
 
-  // PRs the user has already reviewed
   const {
     data: { reviewed },
     hasNext: hasNextReviewed,
     loadNext: loadNextReviewed,
     isLoadingNext: isLoadingNextReviewed,
-  } = usePaginationFragment<
+  } = usePaginationReviewed(data);
+
+  const {
+    data: { changesRequested },
+    hasNext: hasNextChangesRequested,
+    loadNext: loadNextChangesRequested,
+    isLoadingNext: isLoadingNextChangesRequested,
+  } = usePaginationChangesRequested(data);
+
+  const nodes = useCombinedNodes(reviewed, changesRequested);
+
+  const hasNext = hasNextReviewed || hasNextChangesRequested;
+  const isLoadingNext = isLoadingNextReviewed || isLoadingNextChangesRequested;
+
+  const loadNext = () => {
+    if (hasNextReviewed) loadNextReviewed(10);
+    if (hasNextChangesRequested) loadNextChangesRequested(10);
+  };
+
+  return (
+    <PrList title="Reviewed">
+      {nodes.map((pr) => (
+        <Pr key={pr.id} prKey={pr.pr_pullRequest!} />
+      ))}
+      {hasNext && (
+        <LoadMoreButton disabled={isLoadingNext} onClick={loadNext} />
+      )}
+    </PrList>
+  );
+};
+
+const usePaginationReviewed = (key: reviewedPrList_reviewed$key) =>
+  usePaginationFragment<
     ReviewedPrListPaginationQuery,
     reviewedPrList_reviewed$key
   >(
@@ -62,16 +99,13 @@ export const ReviewedPrList = ({ queryRef }: Props) => {
         }
       }
     `,
-    data
+    key
   );
 
-  // PRs where user is a requested reviewer - we'll filter for changes_requested client-side
-  const {
-    data: { changesRequested },
-    hasNext: hasNextChangesRequested,
-    loadNext: loadNextChangesRequested,
-    isLoadingNext: isLoadingNextChangesRequested,
-  } = usePaginationFragment<
+const usePaginationChangesRequested = (
+  key: reviewedPrList_changesRequested$key
+) =>
+  usePaginationFragment<
     ReviewedPrListChangesRequestedPaginationQuery,
     reviewedPrList_changesRequested$key
   >(
@@ -102,41 +136,24 @@ export const ReviewedPrList = ({ queryRef }: Props) => {
         }
       }
     `,
-    data
+    key
   );
 
-  const reviewedPrs = nonnull(reviewed.edges).map(({ node }) => node);
+// Reviewed PRs plus PRs where someone requested changes, deduped by id
+const useCombinedNodes = (
+  reviewed: reviewedPrList_reviewed$data['reviewed'],
+  changesRequested: reviewedPrList_changesRequested$data['changesRequested']
+) => {
+  const reviewedNodes = nonnull(reviewed.edges?.map((e) => e?.node));
+  const changesRequestedNodes = nonnull(
+    changesRequested.edges?.map((e) => e?.node)
+  ).filter((pr) => pr.reviewDecision === 'CHANGES_REQUESTED');
 
-  // Filter to only PRs where someone requested changes (matches Mac app behavior)
-  const changesRequestedPrs = nonnull(changesRequested.edges)
-    .map(({ node }) => node)
-    .filter((pr) => pr?.reviewDecision === 'CHANGES_REQUESTED');
-
-  // Combine both lists, deduplicating by ID
-  const seenIds = new Set<string>();
-  const allPrs = [...reviewedPrs, ...changesRequestedPrs].filter((pr) => {
-    const id = pr?.id;
-    if (!id || seenIds.has(id)) return false;
-    seenIds.add(id);
+  const seen = new Set<string>();
+  return [...reviewedNodes, ...changesRequestedNodes].filter((pr) => {
+    if (!pr.id) return false;
+    if (seen.has(pr.id)) return false;
+    seen.add(pr.id);
     return true;
   });
-
-  const hasNext = hasNextReviewed || hasNextChangesRequested;
-  const isLoadingNext = isLoadingNextReviewed || isLoadingNextChangesRequested;
-
-  const loadNext = () => {
-    if (hasNextReviewed) loadNextReviewed(10);
-    if (hasNextChangesRequested) loadNextChangesRequested(10);
-  };
-
-  return (
-    <PrList title="Reviewed">
-      {allPrs.map((pr) => (
-        <Pr key={pr!.id} prKey={pr!.pr_pullRequest!} />
-      ))}
-      {hasNext && (
-        <LoadMoreButton disabled={isLoadingNext} onClick={loadNext} />
-      )}
-    </PrList>
-  );
 };


### PR DESCRIPTION
Each PR list component inlined a bulky `usePaginationFragment` block followed by `nonnull(edges).map(({ node }) => node)` chains with `node!` assertions at call sites.

Each list now extracts the fragment into a `usePaginationSearch` (or named-by-fragment) helper and node processing into a `useXxxNodes` helper that returns non-null nodes via `nonnull(edges?.map((e) => e?.node))`. Filtering and dedup logic moves into those helpers, leaving component bodies focused on orchestration and rendering. The `nonnull(edges?.map(e => e?.node))` shape keeps both `edges` and `node` referenced in the file so the Relay `unused-fields` lint rule stays happy.